### PR TITLE
Improve ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,18 @@ rust:
   - beta
 os:
   - linux
+  - osx
 
 before_install:
-  - sudo add-apt-repository ppa:elt/libsodium -y
-  - sudo apt-get -qq update
-  - sudo apt-get install -y clang libsodium-dev
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      sudo add-apt-repository ppa:elt/libsodium -y;
+      sudo apt-get -qq update;
+      sudo apt-get install -y clang libsodium-dev;
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update;
+      brew install libsodium;
+    fi
 
 before_script:
   - ./build-liboqs.sh $HOME


### PR DESCRIPTION
This PR does the following:
1. Change how the benchmarks are built. This way they build "instantly". Just `cargo bench` will compile with release mode with optimization, thus it will take ages. This way reuses the artifacts already created by `cargo build` and `cargo test`, thus being almost instant.
2. Remove the now redundant `--all` flag since that is default since Rust 1.21.
3. Add building for macOS. That was very simple, so why not.

I was thinking that maybe you can add an AppVeyor config to make it build for Windows as well? I felt that is probably easier for you. Not that we need it for our current use case really. But it's nice to make sure it works everywhere, and the day we want to integrate wireguard in the client we will benefit from this working on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/oqs-rs/15)
<!-- Reviewable:end -->
