### PR TITLE
Remove named parameter for SIDH CLN16 compressed

### DIFF
--- a/oqs/src/kex.rs
+++ b/oqs/src/kex.rs
@@ -76,7 +76,6 @@ impl From<OqsKexAlg> for ffi::OQS_KEX_alg_name {
 }
 
 static LWE_FRODO_PARAM: &str = "recommended\0";
-static SIDH_CLN16_COMPRESSED_PARAM: &str = "compressedp751\0";
 
 
 /// The main key exchange struct. Used by both Alice and Bob to generate their respective public
@@ -113,7 +112,6 @@ impl<'r> OqsKex<'r> {
         };
         let named_parameters = match algorithm {
             OqsKexAlg::LweFrodo { .. } => LWE_FRODO_PARAM.as_ptr(),
-            OqsKexAlg::SidhCln16Compressed => SIDH_CLN16_COMPRESSED_PARAM.as_ptr(),
             _ => ptr::null(),
         };
 


### PR DESCRIPTION
Liboqs has been updated to not require a "named parameter" for SIDH CLN16 compressed. Making the corresponding adjustment in our code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/oqs-rs/19)
<!-- Reviewable:end -->
