### PR TITLE
Don't use TLS support in jsonrpc-client-http

### DIFF
--- a/oqs-kex-rpc/Cargo.toml
+++ b/oqs-kex-rpc/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "network-programming", "web-programming::http-clie
 error-chain = "0.11"
 oqs = { path = "../oqs", version = "0.1.0", features = ["serde"] }
 jsonrpc-client-core = "0.2"
-jsonrpc-client-http = "0.2"
+jsonrpc-client-http = { version = "0.2", default-features = false }
 jsonrpc-core = "7.1.1"
 jsonrpc-macros = "7.1.1"
 jsonrpc-http-server = "7.1.1"


### PR DESCRIPTION
We don't use TLS in the JSON-RPC calls at all since we don't want to set up certs on the server side and everything happens inside a trusted tunnel anyway. So no need for TLS support in the RPC client then. This deactivates that and thus removes the dependency on `openssl` completely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/oqs-rs/28)
<!-- Reviewable:end -->
