### PR TITLE
Improve readme for mullvad-wg-establish-psk

### DIFF
--- a/mullvad-wg-establish-psk/README.md
+++ b/mullvad-wg-establish-psk/README.md
@@ -5,18 +5,12 @@
 In order to build statically linked binaries, a musl toolchain is needed.
 First, you'll need to install the following packages, using apt-get or similar:
 ```
-autoconf
-automake
-libtool
-make
-musl-dev
-musl-tools
-libclang-dev
+autoconf automake libtool make musl-dev musl-tools libclang-dev
 ```
 
-You'll also need to add a rust target using rustup:
+You'll also need to add a rust target using rustup. We add it to the stable toolchain, since we are going to build against that:
 ```
-rustup target add x86_64-unknown-linux-musl
+rustup target add x86_64-unknown-linux-musl --toolchain stable
 ```
 
 Then, you can run the [`build-static.sh`] script to build the static binaries.


### PR DESCRIPTION
Adding so that the musl toolchain is added to the stable compiler. If you have nightly as default the previous command will install musl for nightly. With this fix it will be added to stable.

Also put the dependencies on one line so it's easy to copy paste, is that ok?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/oqs-rs/30)
<!-- Reviewable:end -->
